### PR TITLE
aws-sdk-go: bump from v1.22.2 to v1.28.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/Microsoft/hcsshim v0.8.6 // indirect
-	github.com/aws/aws-sdk-go v1.22.2
+	github.com/aws/aws-sdk-go v1.28.9
 	github.com/containerd/cgroups v0.0.0-20190717030353-c4b9ac5c7601 // indirect
 	github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50 // indirect
 	github.com/containerd/containerd v1.2.7

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiU
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.8.6 h1:ZfF0+zZeYdzMIVMZHKtDKJvLHj76XCuVae/jNkjj0IA=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
-github.com/aws/aws-sdk-go v1.22.2 h1:uYP58k2Cd9y1qBy8CxTe5ADmdi4kANm8Ul8ch3kkIcQ=
-github.com/aws/aws-sdk-go v1.22.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.28.9 h1:grIuBQc+p3dTRXerh5+2OxSuWFi0iXuxbFdTSg0jaW0=
+github.com/aws/aws-sdk-go v1.28.9/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/cgroups v0.0.0-20190717030353-c4b9ac5c7601 h1:6xW3ogNpFIly0umJGEKzFfGDNUk5rXFE1lJ3/gBmz3U=
 github.com/containerd/cgroups v0.0.0-20190717030353-c4b9ac5c7601/go.mod h1:X9rLEHIqSf/wfK8NsPqxJmeZgW4pcfzdXITDrUSJ6uI=


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Bumps aws-sdk-go version from v1.22.2 to v1.28.9

*Testing done:*
Build succeeds, go test succeeds

Still able to pull from ECR using the resolver:
```
INFO[0000] Pulling from Amazon ECR                       ref="ecr.aws/arn:aws:ecr:us-west-2:SNIP"
ecr.aws/arn:aws:ecr:us-west-2:SNIP: resolving      |--------------------------------------| 
elapsed: 0.5 s                                                        total:   0.0 B (0.0 B/s)                                         
ERRO[0000] failed to get content info                    error="content digest sha256:83219bebeb3b78dfb3d95610279d36bdd77411117adf24ea3d96045fe824bb2e: not found"
ecr.aws/arn:aws:ecr:us-west-2:SNIP:             resolved       |++++++++++++++++++++++++++++++++++++++| 
manifest-sha256:14b9d4440487ed1e0d6df5575649bcc6da49b132dc99cb617eec08c092bbd231: done           |++++++++++++++++++++++++++++++++++++++| 3.0 KiB   Less than a second 5.1 KiB/s  
layer-sha256:83219bebeb3b78dfb3d95610279d36bdd77411117adf24ea3d96045fe824bb2e:    done           |++++++++++++++++++++++++++++++++++++++| 48.9 MiB  21 seconds         2.3 MiB/s  
layer-sha256:433a7d734a901244dc24df8540e4af47a204be60c4457e1cde60f2fa348c84d0:    done           |++++++++++++++++++++++++++++++++++++++| 4.4 KiB   Less than a second 4.8 KiB/s  
layer-sha256:4ec30839b93ef20adb3ccb43e37f7419a7b6c453ee3dcee7a8c6c17494de0ec5:    done           |++++++++++++++++++++++++++++++++++++++| 153.0 B   Less than a second 176.0 B/s  
layer-sha256:7204619de1f4b661133ff152fda4337a20fbff27eb83fc96713ee4fcf26c928e:    done           |++++++++++++++++++++++++++++++++++++++| 147.1 MiB 21 seconds         6.8 MiB/s  
layer-sha256:284395695d28cc998c8a0e40dcf0c872c00a7c8a12960b8eb048a75742c874fc:    done           |++++++++++++++++++++++++++++++++++++++| 175.0 B   Less than a second 198.0 B/s  
config-sha256:78d0bd70842d83b1b2220107dce4b9496bd34c12318da2e3bef07c74677b77a0:   done           |++++++++++++++++++++++++++++++++++++++| 10.2 KiB  Less than a second 11.5 KiB/s 
layer-sha256:2f23cfcf9ffdbbe77e2b8794499f4b58a5ec2f5f2868347592d091e2251815ae:    done           |++++++++++++++++++++++++++++++++++++++| 2.0 KiB   1 second           1.8 KiB/s  
layer-sha256:58960b4b9226bfe426d75bbf4852040c780edfaf285037c17c736ff04493c5a2:    done           |++++++++++++++++++++++++++++++++++++++| 24.6 MiB  11 seconds         2.1 MiB/s  
layer-sha256:5ce1e7a7a9837ee3d9546f5d2616a03f3990ba0499628f875767bd8704d47437:    done           |++++++++++++++++++++++++++++++++++++++| 8.2 MiB   5 seconds          1.6 MiB/s  
layer-sha256:36c822b6011ad36885531a6acc198bd40f2f0c6ef9b7c001edbe776f57f2e214:    done           |++++++++++++++++++++++++++++++++++++++| 26.2 MiB  8 seconds          2.9 MiB/s  
layer-sha256:a3ebe2a3f848b7eea611be332e33503aca0a512c73a8d619bd3304c59df8aa20:    done           |++++++++++++++++++++++++++++++++++++++| 809.0 B   Less than a second 893.0 B/s  
layer-sha256:0e47f424745bdbc0aa0af3b78610c2a45e5860c9505d32f8765eb108bf70e0b6:    done           |++++++++++++++++++++++++++++++++++++++| 253.0 B   1 second           225.0 B/s  
layer-sha256:cd94f4be6883a1098a489cd40e4aea02cf4a09dcdb295c28fb6113ed8837845f:    done           |++++++++++++++++++++++++++++++++++++++| 4.9 MiB   3 seconds          1.4 MiB/s  
layer-sha256:9a63d303b235bae79b8188458bd9440ea5521b5144df9b9e6dee8b78dbff0166:    done           |++++++++++++++++++++++++++++++++++++++| 2.7 KiB   Less than a second 2.8 KiB/s  
elapsed: 22.2s                                                                    total:  260.0  (11.7 MiB/s)                                      
INFO[0022] Pulled successfully!                          img="ecr.aws/arn:aws:ecr:us-west-2:SNIP"
INFO[0022] unpacking...                                  img="ecr.aws/arn:aws:ecr:us-west-2:SNIP"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
