### PR TITLE
Refactor to correctly handle URI combinations

### DIFF
--- a/ecr/ref.go
+++ b/ecr/ref.go
@@ -36,7 +36,6 @@ const (
 
 var (
 	invalidARN = errors.New("ref: invalid ARN")
-	splitRe    = regexp.MustCompile(`[:@]`)
 	// Expecting to match ECR image names of the form:
 	// Example 1: 777777777777.dkr.ecr.us-west-2.amazonaws.com/my_image:latest
 	// Example 2: 777777777777.dkr.ecr.cn-north-1.amazonaws.com.cn/my_image:latest


### PR DESCRIPTION
Signed-off-by: Jacob Vallejo <jakeev@amazon.com>

*Issue #, if available:*

n/a

*Description of changes:*

I found several failing tests while trying to use `ParseImageURI` in place of [the implementation in Bottlerocket's `host-ctr`](https://github.com/bottlerocket-os/bottlerocket/blob/9a1751495f25be35d1746254d661b8b8f8fbfded/sources/host-ctr/cmd/host-ctr/main.go#L445). This addresses those failing test cases by handling more invalid URI cases.

Additionally, this change brings the parsing logic closer to the ARN parser's by using containerd's utilities.

Tests have been added to confirm the desired behavior for both the ARN parser and the image URI code paths.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
