### PR TITLE
resolver: allow push-by-digest, for untagged image

### DIFF
--- a/ecr/resolver.go
+++ b/ecr/resolver.go
@@ -294,12 +294,11 @@ func (r *ecrResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher, e
 		return nil, err
 	}
 
-	// ECR does not allow push by digest; references will include a digest when
-	// the ref is being pushed to a tag to denote *which* digest is the root
-	// descriptor in this push.
+	// References will include a digest when the ref is being pushed to a tag to
+	// denote *which* digest is the root descriptor in this push.
 	tag, digest := ecrSpec.TagDigest()
 	if tag == "" && digest != "" {
-		return nil, errors.New("pusher: cannot use digest reference for push location")
+		log.G(ctx).WithField("ref", ref).Debug("ecr.resolver.pusher: push by digest")
 	}
 
 	// The root descriptor's digest *must* be provided in order to properly tag

--- a/ecr/resolver_test.go
+++ b/ecr/resolver_test.go
@@ -142,15 +142,20 @@ func TestResolveNoResult(t *testing.T) {
 	assert.Equal(t, reference.ErrInvalid, err)
 }
 
-func TestResolvePusherDenyDigest(t *testing.T) {
+func TestResolvePusherAllowsDigest(t *testing.T) {
 	for _, ref := range []string{
 		"ecr.aws/arn:aws:ecr:fake:123456789012:repository/foo/bar@" + testdata.ImageDigest.String(),
 	} {
 		t.Run(ref, func(t *testing.T) {
-			resolver := &ecrResolver{}
+			resolver := &ecrResolver{
+				clients: map[string]ecrAPI{
+					"fake": &fakeECRClient{},
+				},
+			}
+
 			p, err := resolver.Pusher(context.Background(), ref)
-			assert.Error(t, err)
-			assert.Nil(t, p)
+			assert.NoError(t, err)
+			assert.NotNil(t, p)
 		})
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*
```
This change allows users to push images without specifying a tag.

Pushing by digest is desirable when staging images prior to it being
released (tagged in some workflows) or to avoid transient tags in
IMMUTABLE repositories.

Signed-off-by: Jacob Vallejo <jakeev@amazon.com>
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
