### PR TITLE
Make code coverage numbers available on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: build
         run: make build
       - name: test
-        run: make test
+        run: make cover
 
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /bin
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ $(COPY_BINARY): $(SOURCES)
 test: $(SOURCES)
 	go test -v $(shell go list ./... | grep -v '/vendor/')
 
+.PHONY: cover
+cover: $(SOURCES)
+	mkdir -p tmp
+	go test -coverprofile=tmp/coverage.out -v $(shell go list ./... | grep -v '/vendor/')
+	go tool cover -html=tmp/coverage.out -o tmp/coverage.html
+	@echo Code coverage report is generated as tmp/coverage.html
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

NA

*Description of changes:*

The change adds `cover` target and uses that from GitHub Actions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
