### PR TITLE
Produce errors when parsing a media type or manifest fails

### DIFF
--- a/ecr/resolver_test.go
+++ b/ecr/resolver_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/awslabs/amazon-ecr-containerd-resolver/ecr/internal/testdata"
 )
@@ -49,7 +50,13 @@ func TestParseImageManifestMediaType(t *testing.T) {
 	} {
 		t.Run(sample.MediaType(), func(t *testing.T) {
 			t.Logf("content: %s", sample.Content())
-			actual := parseImageManifestMediaType(context.Background(), sample.Content())
+			actual, err := parseImageManifestMediaType(context.Background(), sample.Content())
+			if sample == testdata.EmptySample {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, ErrInvalidManifest))
+				return
+			}
+			require.NoError(t, err)
 			assert.Equal(t, sample.MediaType(), actual)
 		})
 	}


### PR DESCRIPTION
*Issue #, if available:*

#18 

*Description of changes:*

Changed the signature of parseImageManifestMediaType to return an error separately

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
