### PR TITLE
feat: bump go requirement to 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.15', '1.14', '1.13' ]
+        go: [ '1.18', '1.17' ]
     name: Go ${{ matrix.go }} build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18', '1.17' ]
+        go: [ '1.19', '1.18', '1.17' ]
     name: Go ${{ matrix.go }} build
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -80,10 +80,8 @@ This support is backed by the [htcat library](https://github.com/htcat/htcat).
 
 ## Building
 
-The Amazon ECR containerd resolver manages its dependencies with [Go 1.11
-modules](https://github.com/golang/go/wiki/Modules) and works best when used
-with Go 1.11 or greater.  If you have Go 1.11 or greater installed, you can
-build the example programs with `make`.
+The Amazon ECR containerd resolver manages its dependencies with [Go modules](https://github.com/golang/go/wiki/Modules) and requires Go 1.17 or greater.
+If you have Go 1.17 or greater installed, you can build the example programs with `make`.
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,21 +1,52 @@
 module github.com/awslabs/amazon-ecr-containerd-resolver
 
-go 1.12
+go 1.17
 
 require (
-	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/aws/aws-sdk-go v1.32.13
 	github.com/containerd/containerd v1.5.13
 	github.com/docker/go-units v0.5.0
-	github.com/gogo/googleapis v1.4.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/htcat/htcat v1.0.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220303224323-02efb9a75ee1
-	github.com/opencontainers/selinux v1.8.4 // indirect
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+)
+
+require (
+	github.com/Microsoft/go-winio v0.5.0 // indirect
+	github.com/Microsoft/hcsshim v0.8.24 // indirect
+	github.com/bits-and-blooms/bitset v1.2.0 // indirect
+	github.com/containerd/cgroups v1.0.3 // indirect
+	github.com/containerd/console v1.0.2 // indirect
+	github.com/containerd/continuity v0.1.0 // indirect
+	github.com/containerd/fifo v1.0.0 // indirect
+	github.com/containerd/ttrpc v1.1.0 // indirect
+	github.com/containerd/typeurl v1.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
+	github.com/gogo/googleapis v1.4.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/jmespath/go-jmespath v0.3.0 // indirect
+	github.com/klauspost/compress v1.11.13 // indirect
+	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/sys/mountinfo v0.4.1 // indirect
+	github.com/opencontainers/runc v1.0.2 // indirect
+	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
+	github.com/opencontainers/selinux v1.8.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.opencensus.io v0.22.3 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	golang.org/x/text v0.3.4 // indirect
+	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect
 	google.golang.org/grpc v1.39.1 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
*Issue #, if available:*

#44

*Description of changes:*

This updates the versions of Go used to allow dependencies to be updated (see #44).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
