### PR TITLE
Removed all references to pkg errors and replaced with fmt.Errorf

### DIFF
--- a/ecr/fetcher_test.go
+++ b/ecr/fetcher_test.go
@@ -18,6 +18,7 @@ package ecr
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -35,7 +36,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,8 +108,7 @@ func TestFetchForeignLayerNotFound(t *testing.T) {
 
 	_, err := fetcher.Fetch(context.Background(), desc)
 	assert.Error(t, err)
-	cause := errors.Cause(err)
-	assert.Equal(t, errdefs.ErrNotFound, cause)
+	assert.True(t, errors.Is(err, errdefs.ErrNotFound))
 }
 
 func TestFetchManifest(t *testing.T) {

--- a/ecr/internal/testdata/media_type.go
+++ b/ecr/internal/testdata/media_type.go
@@ -13,7 +13,7 @@ type MediaTypeSample interface {
 // MediaTypeSample provides a sample document for a given mediaType.
 type mediaTypeSample struct {
 	mediaType string
-	content string
+	content   string
 }
 
 // MediaType is the defined sample's actual mediaType.
@@ -29,7 +29,7 @@ func (s *mediaTypeSample) Content() string {
 // EmptySample is an edge case sample, use
 var EmptySample MediaTypeSample = &mediaTypeSample{
 	mediaType: "",
-	content: `{}`,
+	content:   `{}`,
 }
 
 func WithMediaTypeRemoved(src MediaTypeSample) MediaTypeSample {
@@ -47,6 +47,6 @@ func WithMediaTypeRemoved(src MediaTypeSample) MediaTypeSample {
 	}
 	return &mediaTypeSample{
 		mediaType: src.MediaType(),
-		content: string(data),
+		content:   string(data),
 	}
 }

--- a/ecr/internal/testdata/media_type_oci_image.go
+++ b/ecr/internal/testdata/media_type_oci_image.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-  ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var OCIImageManifest MediaTypeSample = &mediaTypeSample{

--- a/ecr/layer_writer.go
+++ b/ecr/layer_writer.go
@@ -17,6 +17,7 @@ package ecr
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"time"
@@ -30,7 +31,6 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 type layerWriter struct {

--- a/ecr/pusher.go
+++ b/ecr/pusher.go
@@ -17,6 +17,8 @@ package ecr
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -29,7 +31,6 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -73,7 +74,7 @@ func (p ecrPusher) pushManifest(ctx context.Context, desc ocispec.Descriptor) (c
 	if exists {
 		log.G(ctx).Debug("ecr.pusher.manifest: content already on remote")
 		p.markStatusExists(ctx, desc)
-		return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "content %v on remote", desc.Digest)
+		return nil, fmt.Errorf("content %v on remote: %w", desc.Digest, errdefs.ErrAlreadyExists)
 	}
 
 	ref := p.markStatusStarted(ctx, desc)
@@ -114,7 +115,7 @@ func (p ecrPusher) pushBlob(ctx context.Context, desc ocispec.Descriptor) (conte
 	if exists {
 		log.G(ctx).Debug("ecr.pusher.blob: content already on remote")
 		p.markStatusExists(ctx, desc)
-		return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "content %v on remote", desc.Digest)
+		return nil, fmt.Errorf("content %v on remote: %w", desc.Digest, errdefs.ErrAlreadyExists)
 	}
 
 	ref := p.markStatusStarted(ctx, desc)

--- a/ecr/pusher_test.go
+++ b/ecr/pusher_test.go
@@ -17,6 +17,7 @@ package ecr
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -70,7 +70,7 @@ func TestPushManifestReturnsManifestWriter(t *testing.T) {
 				assert.Equal(t, repository, aws.StringValue(input.RepositoryName))
 
 				assert.ElementsMatch(t, []*ecr.ImageIdentifier{
-					&ecr.ImageIdentifier{ImageDigest: aws.String(imageDigest)}},
+					{ImageDigest: aws.String(imageDigest)}},
 					input.ImageIds,
 					"should have requested image by its digest")
 
@@ -148,8 +148,7 @@ func TestPushManifestAlreadyExists(t *testing.T) {
 	start := time.Now()
 	_, err := pusher.Push(context.Background(), desc)
 	assert.Error(t, err)
-	cause := errors.Cause(err)
-	assert.Equal(t, errdefs.ErrAlreadyExists, cause)
+	assert.True(t, errors.Is(err, errdefs.ErrAlreadyExists))
 	end := time.Now()
 
 	refKey := remotes.MakeRefKey(context.Background(), desc)
@@ -269,8 +268,7 @@ func TestPushBlobAlreadyExists(t *testing.T) {
 	start := time.Now()
 	_, err := pusher.Push(context.Background(), desc)
 	assert.Error(t, err)
-	cause := errors.Cause(err)
-	assert.Equal(t, errdefs.ErrAlreadyExists, cause)
+	assert.True(t, errors.Is(err, errdefs.ErrAlreadyExists))
 	end := time.Now()
 
 	refKey := remotes.MakeRefKey(context.Background(), desc)

--- a/ecr/ref.go
+++ b/ecr/ref.go
@@ -16,6 +16,8 @@
 package ecr
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -25,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/containerd/containerd/reference"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -117,7 +118,7 @@ func ParseImageURI(input string) (ECRSpec, error) {
 		//
 		// https://github.com/opencontainers/go-digest/blob/ea51bea511f75cfa3ef6098cc253c5c3609b037a/digest.go#L110-L115
 		if err != nil && err != digest.ErrDigestUnsupported {
-			return ECRSpec{}, errors.Wrap(err, errInvalidImageURI.Error())
+			return ECRSpec{}, fmt.Errorf("%v: %w", errInvalidImageURI.Error(), err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220303224323-02efb9a75ee1
 	github.com/opencontainers/selinux v1.8.4 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4


### PR DESCRIPTION
Signed-off-by: Yasin Turan <turyasin@amazon.com>

Issue #38 

Removed all references to pkg errors(archived) and replaced with fmt.Errorf().


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
