### PR TITLE
Harden regex by denoting host boundary

### DIFF
--- a/ecr/ref.go
+++ b/ecr/ref.go
@@ -41,7 +41,7 @@ var (
 	// Example 1: 777777777777.dkr.ecr.us-west-2.amazonaws.com/my_image:latest
 	// Example 2: 777777777777.dkr.ecr.cn-north-1.amazonaws.com.cn/my_image:latest
 	// TODO: Support ECR FIPS endpoints, i.e "ecr-fips" in the URL instead of "ecr"
-	ecrRegex           = regexp.MustCompile(`(^[a-zA-Z0-9][a-zA-Z0-9-_]*)\.dkr\.ecr\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.amazonaws\.com(\.cn)?.*`)
+	ecrRegex           = regexp.MustCompile(`(^[a-zA-Z0-9][a-zA-Z0-9-_]*)\.dkr\.ecr\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.amazonaws\.com(\.cn)?/.*`)
 	errInvalidImageURI = errors.New("ecrspec: invalid image URI")
 )
 


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
Hardens the ECR host regex by denoting the host boundary for matching.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
