### PR TITLE
fix: redact HTTP query values from logs

### DIFF
--- a/ecr/internal/util/http/redact.go
+++ b/ecr/internal/util/http/redact.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * 	http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package http
+
+import (
+	"errors"
+	"net/url"
+)
+
+// RedactHTTPQueryValuesFromURLError is a log utility to parse an error as a URL
+// error and redact HTTP query values to prevent leaking sensitive information
+// like encoded credentials or tokens.
+func RedactHTTPQueryValuesFromURLError(err error) error {
+	var urlErr *url.Error
+
+	if err != nil && errors.As(err, &urlErr) {
+		urlErr.URL = RedactHTTPQueryValuesFromURL(urlErr.URL)
+		return urlErr
+	}
+
+	return err
+}
+
+// RedactHTTPQueryValuesFromURL is a log utility to parse a raw URL as a URL
+// and redact HTTP query values to prevent leaking sensitive information
+// like encoded credentials or tokens.
+func RedactHTTPQueryValuesFromURL(rawURL string) string {
+	url, urlParseErr := url.Parse(rawURL)
+	if urlParseErr == nil && url != nil {
+		if query := url.Query(); len(query) > 0 {
+			for k := range query {
+				query.Set(k, "redacted")
+			}
+			url.RawQuery = query.Encode()
+		}
+		return url.Redacted()
+	}
+	return rawURL
+}

--- a/ecr/internal/util/http/redact_test.go
+++ b/ecr/internal/util/http/redact_test.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * 	http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package http
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const (
+	// mockURL is a fake URL modeling ecr resolver fetching content from S3.
+	mockURL = "https://s3.us-east-1.amazonaws.com/981ebdad55863b3631dce86a228a3ea230dc87673a06a7d216b1275d4dd707c9/12d7153d7eee2fd595a25e5378384f1ae4b6a1658298a54c5bd3f951ec50b7cb"
+
+	// mockQuery is a fake HTTP query with sensitive information which should be redacted.
+	mockQuery = "?username=admin&password=admin"
+
+	// redactedQuery is the expected result of redacting mockQuery.
+	// The query values will be sorted by key as a side-effect of encoding the URL query string back into the URL.
+	// See https://pkg.go.dev/net/url#Values.Encode
+	redactedQuery = "?password=redacted&username=redacted"
+)
+
+func TestRedactHTTPQueryValuesFromURLError(t *testing.T) {
+	testCases := []struct {
+		Name        string
+		Description string
+		Err         error
+		Assert      func(*testing.T, error)
+	}{
+		{
+			Name:        "NilError",
+			Description: "Utility should handle nil error gracefully",
+			Err:         nil,
+			Assert: func(t *testing.T, actual error) {
+				if actual != nil {
+					t.Fatalf("Expected nil error, got '%v'", actual)
+				}
+			},
+		},
+		{
+			Name:        "NonURLError",
+			Description: "Utility should not modify an error if error is not a URL error",
+			Err:         errors.New("this error is not a URL error"),
+			Assert: func(t *testing.T, actual error) {
+				const expected = "this error is not a URL error"
+				if strings.Compare(expected, actual.Error()) != 0 {
+					t.Fatalf("Expected '%s', got '%v'", expected, actual)
+				}
+			},
+		},
+		{
+			Name:        "ErrorWithNoHTTPQuery",
+			Description: "Utility should not modify an error if no HTTP queries are present.",
+			Err: &url.Error{
+				Op:  "GET",
+				URL: mockURL,
+				Err: errors.New("connect: connection refused"),
+			},
+			Assert: func(t *testing.T, actual error) {
+				const expected = "GET \"" + mockURL + "\": connect: connection refused"
+				if strings.Compare(expected, actual.Error()) != 0 {
+					t.Fatalf("Expected '%s', got '%v'", expected, actual)
+				}
+			},
+		},
+		{
+			Name:        "ErrorWithHTTPQuery",
+			Description: "Utility should redact HTTP query values in errors to prevent logging sensitive information.",
+			Err: &url.Error{
+				Op:  "GET",
+				URL: mockURL + mockQuery,
+				Err: errors.New("connect: connection refused"),
+			},
+			Assert: func(t *testing.T, actual error) {
+				const expected = "GET \"" + mockURL + redactedQuery + "\": connect: connection refused"
+				if strings.Compare(expected, actual.Error()) != 0 {
+					t.Fatalf("Expected '%s', got '%v'", expected, actual)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			actual := RedactHTTPQueryValuesFromURLError(testCase.Err)
+			testCase.Assert(t, actual)
+		})
+	}
+}
+
+func TestRedactHTTPQueryValuesFromURL(t *testing.T) {
+	testCases := []struct {
+		Name        string
+		Description string
+		URL         string
+		Expected    string
+	}{
+		{
+			Name:        "EmptyURL",
+			Description: "Utility should gracefully handle an empty URL input",
+			URL:         "",
+			Expected:    "",
+		},
+		{
+			Name:        "ValidURLWithoutQuery",
+			Description: "Utility should not modify a valid URL with no HTTP query",
+			URL:         mockURL,
+			Expected:    mockURL,
+		},
+		{
+			Name:        "ValidURLWithQuery",
+			Description: "Utility should redact HTTP query values",
+			URL:         mockURL + mockQuery,
+			Expected:    mockURL + redactedQuery,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			actual := RedactHTTPQueryValuesFromURL(testCase.URL)
+			if strings.Compare(testCase.Expected, actual) != 0 {
+				t.Fatalf("Expected '%s', got '%s'", testCase.Expected, actual)
+			}
+		})
+	}
+}

--- a/ecr/internal/util/oci/redact.go
+++ b/ecr/internal/util/oci/redact.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * 	http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package oci
+
+import (
+	httputil "github.com/awslabs/amazon-ecr-containerd-resolver/ecr/internal/util/http"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// RedactDescriptor returns a copy of the provided image descriptor
+// with its URLs redacted.
+func RedactDescriptor(desc ocispec.Descriptor) ocispec.Descriptor {
+	for i, url := range desc.URLs {
+		desc.URLs[i] = httputil.RedactHTTPQueryValuesFromURL(url)
+	}
+	return desc
+}

--- a/ecr/internal/util/oci/redact_test.go
+++ b/ecr/internal/util/oci/redact_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * 	http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package oci
+
+import (
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestRedactDescriptor(t *testing.T) {
+	testCases := []struct {
+		Name        string
+		Description string
+		Descriptor  ocispec.Descriptor
+		Assert      func(*testing.T, ocispec.Descriptor)
+	}{
+		{
+			Name:        "RedactDescriptorEmptyURLs",
+			Description: "Utility should make a descriptor copy with no URLs",
+			Descriptor: ocispec.Descriptor{
+				URLs: []string{},
+			},
+			Assert: func(t *testing.T, actual ocispec.Descriptor) {
+				if len(actual.URLs) != 0 {
+					t.Fatalf("Expected length of 0, got length %d", len(actual.URLs))
+				}
+			},
+		},
+		{
+			Name:        "RedactDescriptorURLs",
+			Description: "Utility should make a descriptor copy with redacted URLs",
+			Descriptor: ocispec.Descriptor{
+				URLs: []string{
+					"s3.amazon.com/foo/bar?token=12345",
+					"s3.amazon.com/foo/baz?username=admin&password=admin",
+				},
+			},
+			Assert: func(t *testing.T, actual ocispec.Descriptor) {
+				if len(actual.URLs) != 2 {
+					t.Fatalf("Expected length of 2, got length %d", len(actual.URLs))
+				}
+				const expectedURL1 = "s3.amazon.com/foo/bar?token=redacted"
+				if actual.URLs[0] != expectedURL1 {
+					t.Fatalf("Expected %s; got %s", expectedURL1, actual.URLs[0])
+				}
+				const expectedURL2 = "s3.amazon.com/foo/baz?password=redacted&username=redacted"
+				if actual.URLs[1] != expectedURL2 {
+					t.Fatalf("Expected %s; got %s", expectedURL2, actual.URLs[1])
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			actual := RedactDescriptor(testCase.Descriptor)
+			testCase.Assert(t, actual)
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Error messages returned from ECR may contain sensitive information such as a full signed S3 URL. This change will redact HTTP query values from URL errors returned by the HTTP client so the sensitive information is not propagated up the stack or logged to disk.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
