### PR TITLE
Add dependabot configuration for GitHub Actions packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: /
+  # Automatic upgrade for Go modules.
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"
+
+  # Automatic upgrade for GitHub Actions packages.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
*Issue #, if available:*
N/A

CI is showing deprecation warnings which can be resolved by dependabot automation.

*Description of changes:*
This change adds dependabot automation for GitHub Actions package updates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
