### PR TITLE
Update golangci-lint version to v1.57.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.51
+          version: v1.57.2


### PR DESCRIPTION
*Issue #, if available:*
N/A

New versions of golangci-lint are available with latest Golang support.

*Description of changes:*
This change updates the golangci-lint version to v1.57.2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
