### PR TITLE
Update Go 1.23, 1.24 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.21', '1.22' ]
+        go: [ '1.23', '1.24' ]
     name: Go ${{ matrix.go }} build
     steps:
       - uses: actions/checkout@v4
@@ -24,8 +24,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.57.2
+          version: v1.64.7


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change updates Go in CI to unblock dependabot PRs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
